### PR TITLE
Improve robustness and performance

### DIFF
--- a/run_pipeline
+++ b/run_pipeline
@@ -52,15 +52,12 @@ fi
 # Validate inputs
 validate_glob() {
     local pattern="$1"
-    local files=( $pattern )
-
-    # Check if the expansion returns anything
-    if [ ${#files[@]} -eq 0 ]; then
+    if compgen -G "$pattern" > /dev/null; then
+        return 0
+    else
         echo "No files match the glob '$pattern'."
         echo "Please provide a valid glob pattern."
-        return 1 # Return 1 for error state
-    else
-        return 0 # Return 0 for success state
+        return 1
     fi
 }
 
@@ -96,18 +93,19 @@ wait
 log "\nIntermediate hash files (first char of filename is the shard):"
 ls "$TMP_DIR/"
 
-SHARDS=($(ls "$TMP_DIR/" | sed 's/^\(.\).*/\1/' | sort -u))
+SHARDS=($(ls "$TMP_DIR" | sed 's/^\(.\).*/\1/' | sort -u))
 
 log "\nDeduping files based on their hashes..."
 
 for SHARD in "${SHARDS[@]}"; do
-    ./target/release/dedup_hashes "$TMP_DIR/${SHARD}_*" "$OUTPUT_DIR/$SHARD.csv" &
+    ./target/release/dedup_hashes "$TMP_DIR"/${SHARD}_* "$OUTPUT_DIR/$SHARD.csv" &
 done
 
 wait
 
 log "\nUniques (first char of the filename is the shard):"
-ls $OUTPUT_DIR/*.csv
+ls "$OUTPUT_DIR"/*.csv
 
 echo ""
-log "Run the following command to get uniques: ls $OUTPUT_DIR/*.csv | xargs cat"
+log "Run the following command to get uniques: ls '$OUTPUT_DIR'/*.csv | xargs cat"
+

--- a/src/bin/dedup_hashes.rs
+++ b/src/bin/dedup_hashes.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use env_logger;
 use log;
 use record_linker::file_iterator::FileIterator;
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::PathBuf;
@@ -34,7 +34,7 @@ fn main() -> io::Result<()> {
     let mut output_file = File::create(&params.output_file)?;
 
     // result data structures
-    let mut results: HashMap<String, Vec<String>> = HashMap::new();
+    let mut seen: HashSet<String> = HashSet::new();
     let mut unique_files: u32 = 0;
     let mut total_files: u32 = 0;
 
@@ -48,20 +48,17 @@ fn main() -> io::Result<()> {
 
         for line_result in reader.lines() {
             let line = line_result?;
-            let entry: Vec<&str> = line.split(",").collect();
-            assert!(entry.len() == 2);
-            let hash = entry[0].to_owned();
-            let file_path = entry[1].to_owned();
-            let hash_vec = results.entry(hash).or_insert(Vec::new());
-            hash_vec.push(file_path);
-            total_files += 1;
+            let mut parts = line.splitn(2, ',');
+            if let (Some(hash), Some(file_path)) = (parts.next(), parts.next()) {
+                total_files += 1;
+                if seen.insert(hash.to_owned()) {
+                    writeln!(output_file, "{},{}", hash, file_path)?;
+                    unique_files += 1;
+                }
+            } else {
+                log::warn!("Malformed line: {}", line);
+            }
         }
-    }
-
-    for (hash, hash_vec) in results {
-        let line = format!("{},{}\n", hash, hash_vec.iter().next().unwrap());
-        output_file.write(line.as_bytes())?;
-        unique_files += 1;
     }
 
     let duration = start.elapsed();

--- a/src/bin/hash_documents.rs
+++ b/src/bin/hash_documents.rs
@@ -36,7 +36,6 @@ fn main() -> io::Result<()> {
     let mut shard_store = ShardStore::new(&params.output_dir, file_suffix.clone());
 
     // result data structures
-    let mut results = Vec::new();
     let mut shard_counts: HashMap<char, u32> = HashMap::new();
 
     // initial report
@@ -53,10 +52,14 @@ fn main() -> io::Result<()> {
         match file {
             Ok(path) => {
                 let hash = path.blake3()?;
-                let shard = hash.chars().next().unwrap();
-                let path_str = path.to_str().unwrap().to_owned();
+                let shard = hash
+                    .chars()
+                    .next()
+                    .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "empty hash"))?;
+                let path_str = path.to_string_lossy().into_owned();
 
-                results.push((shard, hash, path_str));
+                let line = format!("{},{}\n", hash, path_str);
+                shard_store.write(shard, line.as_bytes())?;
 
                 let count = shard_counts.entry(shard).or_insert(0);
                 *count += 1;
@@ -68,10 +71,7 @@ fn main() -> io::Result<()> {
         }
     }
 
-    for (shard, hash, file_path) in results {
-        let line = format!("{},{}\n", hash, file_path);
-        shard_store.write(shard, line.as_bytes())?;
-    }
+    shard_store.finalize()?;
 
     let duration = start.elapsed();
 

--- a/src/file_blake3.rs
+++ b/src/file_blake3.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{self, BufReader, Read};
+use std::io::{self, Read};
 use std::path::PathBuf;
 
 pub trait Blake3Hash {
@@ -9,27 +9,24 @@ pub trait Blake3Hash {
 impl Blake3Hash for PathBuf {
     fn blake3(&self) -> io::Result<String> {
         // Open the file
-        let file = File::open(self)?;
+        let mut file = File::open(self)?;
 
-        // Create a buffered reader for efficient reading
-        let mut reader = BufReader::new(file);
-
-        // Initialize the SHA-256 hasher
+        // Initialize the hasher
         let mut hasher = blake3::Hasher::new();
 
-        // Buffer for reading chunks
-        let mut buffer = [0; 1024];
+        // Buffer for reading chunks (64 KiB)
+        let mut buffer = [0u8; 64 * 1024];
 
         // Read the file and update the hash in chunks
-        while let Ok(bytes_read) = reader.read(&mut buffer) {
+        loop {
+            let bytes_read = file.read(&mut buffer)?;
             if bytes_read == 0 {
                 break; // End of file
             }
-            hasher.update(&buffer[..bytes_read]); // Update the hash with the read bytes
+            hasher.update(&buffer[..bytes_read]);
         }
 
         // Get the final digest and convert it to a hexadecimal string
-        let digest = hasher.finalize();
-        Ok(digest.to_string())
+        Ok(hasher.finalize().to_string())
     }
 }

--- a/src/file_iterator.rs
+++ b/src/file_iterator.rs
@@ -11,7 +11,7 @@ pub struct FileIterator {
 impl FileIterator {
     // Constructor to create a new FileIterator for a given glob
     pub fn new(pattern: &String) -> io::Result<Self> {
-        let paths = glob(pattern.as_str()).unwrap();
+        let paths = glob(pattern.as_str()).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
         let entries = paths.map(|result| match result {
             Ok(path) => Ok(path),
             Err(err) => Err(io::Error::new(io::ErrorKind::Other, err)),

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -1,17 +1,9 @@
-use rand::{distributions::Uniform, Rng};
+use rand::{distributions::Alphanumeric, Rng};
 
 pub fn random_string(len: usize) -> String {
-    // Define the character set to sample from: 0-9a-z
-    let chars: Vec<char> = ('0'..'9').chain('a'..'z').collect();
-
-    // Create a uniform distribution to sample indices of the character set
-    let dist = Uniform::new(0, chars.len());
-
-    // Create a random generator (thread-local)
-    let mut rng = rand::thread_rng();
-
-    // Generate the random string of the specified length
-    (0..len)
-        .map(|_| chars[rng.sample(dist)]) // Sample a character for each position
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .map(|c| char::from(c).to_ascii_lowercase())
+        .take(len)
         .collect()
 }

--- a/src/shard_store.rs
+++ b/src/shard_store.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
-use std::io::{self, Write};
+use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
 
 #[derive(Debug)]
 pub struct ShardStore {
-    output_files: HashMap<char, File>,
+    output_files: HashMap<char, BufWriter<File>>,
     output_dir: PathBuf,
     file_suffix: String,
 }
@@ -20,25 +20,30 @@ impl ShardStore {
     }
 
     pub fn finalize(&mut self) -> io::Result<()> {
-        for file in self.output_files.values_mut() {
-            file.flush()?;
+        for writer in self.output_files.values_mut() {
+            writer.flush()?;
         }
         Ok(())
     }
 
     pub fn write(&mut self, shard: char, buf: &[u8]) -> io::Result<()> {
-        let file = self.output_files.entry(shard).or_insert(
-            OpenOptions::new()
+        if !self.output_files.contains_key(&shard) {
+            let path = self
+                .output_dir
+                .clone()
+                .join(format!("{}_{}.csv", shard, self.file_suffix));
+            let file = OpenOptions::new()
                 .create(true)
                 .write(true)
                 .append(true)
-                .open(
-                    self.output_dir
-                        .clone()
-                        .join(format!("{}_{}.csv", shard, self.file_suffix)),
-                )?,
-        );
-        file.write_all(buf)?;
+                .open(path)?;
+            self.output_files.insert(shard, BufWriter::new(file));
+        }
+        let writer = self
+            .output_files
+            .get_mut(&shard)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "shard not initialized"))?;
+        writer.write_all(buf)?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Stream hashed file records directly to sharded outputs and handle non-UTF-8 paths
- Deduplicate hash CSVs while streaming and handling malformed input
- Buffer shard writes and harden file iteration, hashing, random ID generation, and pipeline script quoting

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689adfa41ea4832489997dfa12d3e422