### PR TITLE
Add CI workflow for unit and end-to-end tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Run unit tests
+        run: cargo test
+      - name: Build binaries
+        run: cargo build --release
+      - name: End-to-end run_pipeline test
+        run: |
+          mkdir -p e2e_input e2e_output
+          echo 'foo' > e2e_input/a.txt
+          echo 'bar' > e2e_input/b.txt
+          echo 'foo' > e2e_input/c.txt
+          ./run_pipeline 'e2e_input/*.txt' e2e_output
+          test "$(cat e2e_output/*.csv | wc -l)" -eq 2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Record Linker
 
+[![CI](https://github.com/mweiden/record_linker/actions/workflows/ci.yml/badge.svg)](https://github.com/mweiden/record_linker/actions/workflows/ci.yml)
+
 Demonstration software for the following problem:
 
 > Deduplicate a large corpus of documents:


### PR DESCRIPTION
## Summary
- add GitHub Action to run `cargo test`
- build release binaries and run `run_pipeline` on sample files to verify end-to-end behavior

## Testing
- `cargo test`
- `cargo build --release`
- `./run_pipeline 'e2e_input/*.txt' e2e_output`


------
https://chatgpt.com/codex/tasks/task_e_689ae39722d883248fa55823136c84e4